### PR TITLE
Set inflictor to entity instead of metatable

### DIFF
--- a/lua/autorun/statuseffects.lua
+++ b/lua/autorun/statuseffects.lua
@@ -283,7 +283,7 @@ if !STATUS_PLY.SetWalkSpeedOld then
 		STATUS_ENT.IgniteOld = STATUS_ENT.Ignite
 		function STATUS_ENT:Ignite(duration,radius,inflictor)
 			if !radius then radius = 0 end
-			if !inflictor then inflictor = STATUS_ENT end
+			if !inflictor then inflictor = self end
 			self:InflictStatusEffect("Burning",duration,radius,inflictor)
 		end
 		


### PR DESCRIPTION
Anything that uses Ignite (that does not pass a third argument by default) will have it's inflictor set to the metatable of Entity.
InflictStatusEffect uses net.WriteEntity for the inflictor and will throw an error